### PR TITLE
[groff] Initial plan and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+# groff
+
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.groff?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=153&branchName=master)
+
+Groff (GNU troff) is a typesetting system that reads plain text mixed with formatting commands and produces formatted output. Output may be PostScript or PDF, html, or ASCII/UTF8 for display at the terminal. Formatting commands may be either low-level typesetting requests (“primitives”) or macros from a supplied set. Users may also write their own macros. All three may be combined.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/controls/groff_works.rb
+++ b/controls/groff_works.rb
@@ -1,0 +1,18 @@
+base_dir = input("base_dir", value: "bin")
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input("plan_name", value: "groff")
+plan_ident = "#{plan_origin}/#{plan_name}"
+
+hab_pkg_path = command("hab pkg path #{plan_ident}")
+describe hab_pkg_path do
+  its('exit_status') { should eq 0 }
+  its('stdout') { should_not be_empty }
+end
+
+target_dir = File.join(hab_pkg_path.stdout.strip, base_dir)
+
+describe command("#{File.join(target_dir, plan_name)} -v") do
+  its('stdout') { should match /GNU groff version [0-9]+.[0-9]+.[0-9]+/  }
+  its('stderr') { should eq '' }
+  its('exit_status') { should eq 0 }
+end

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,7 +1,7 @@
-name: {{plan_name}}
-title: Habitat Core Plan {{plan_name}}
+name: groff
+title: Habitat Core Plan groff
 maintainer: humans@habitat.sh
-summary: InSpec controls for testing Habitat Core Plan {{plan_name}}
+summary: InSpec controls for testing Habitat Core Plan groff
 copyright: humans@habitat.sh
 copyright_email: humans@habitat.sh
 version: 0.1.0

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,19 @@
+pkg_name=groff
+pkg_origin=core
+pkg_version=1.22.3
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=('GPL-3.0')
+pkg_description="Groff (GNU troff) is a typesetting system that reads plain text mixed with formatting commands and produces formatted output. Output may be PostScript or PDF, html, or ASCII/UTF8 for display at the terminal. Formatting commands may be either low-level typesetting requests (“primitives”) or macros from a supplied set. Users may also write their own macros. All three may be combined."
+pkg_upstream_url=https://www.gnu.org/software/groff/
+pkg_source=http://ftp.gnu.org/gnu/groff/groff-${pkg_version}.tar.gz
+pkg_shasum=3a48a9d6c97750bfbd535feeb5be0111db6406ddb7bb79fc680809cda6d828a5
+pkg_bin_dirs=(bin)
+pkg_build_deps=(
+  core/gcc
+  core/gcc-libs
+  core/make
+  core/perl
+)
+pkg_deps=(
+  core/gcc-libs
+)


### PR DESCRIPTION
Command: `hab pkg path mindnumbing/groff`
     ✔  exit_status is expected to eq 0
     ✔  stdout is expected not to be empty
  Command: `/hab/pkgs/mindnumbing/groff/1.22.3/20200609091310/bin/groff -v`
     ✔  stdout is expected to match /GNU groff version [0-9]+.[0-9]+.[0-9]+/
     ✔  stderr is expected to eq ""
     ✔  exit_status is expected to eq 0

Signed-off-by: Steven Marshall <SMarshall@chef.io>